### PR TITLE
[Fix] Prevent fetching data twice within the useEffect

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -32,6 +32,7 @@ export default function Page() {
   const [dataAgreement, setDataAgreement] = useState<DataAgreementRequest | null>(null);
 
   useEffect(() => {
+    const abortController = new AbortController();
     /** get data agreement */
     (async () => {
       const dataAgreement = await getDataAgreement();
@@ -39,6 +40,10 @@ export default function Page() {
     })().catch((err) => {
       console.error(err);
     });
+    /** cleanup */
+    return () => {
+      abortController.abort();
+    };
   }, []);
 
   const handleClick = async (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/src/app/webapp/home/page.tsx
+++ b/src/app/webapp/home/page.tsx
@@ -32,6 +32,7 @@ export default function Page() {
   const visitPer = 5; // 100%/5件
 
   useEffect(() => {
+    const abortController = new AbortController();
     /** today */
     setDate(new Date());
     /** error status */
@@ -58,6 +59,10 @@ export default function Page() {
       console.error(err);
       setStatus(errorStatus);
     });
+    /** cleanup */
+    return () => {
+      abortController.abort();
+    };
   }, []);
 
   const startRecommend = () => {


### PR DESCRIPTION
# Features

TEAM PIPLUP 🐧

## What does this PR do?

この PR の内容を記入してください。修正の場合は、**Before** と **After** のスクリーンショットも並べてください。

- Add cleanup func to some useEffect to prevent fetching data twice

## Todo

この PR で実装できていない UI や機能、また、作業予定の項目を記入してください。

- None

## Before submitting

この PR を `Open` する前に、確認すべき項目。確認済みの項目にチェック(`[x]`)をつける。

> **Warning**
>
> 以下はチェックのみ編集を許可する。(内容の追加および変更は禁じる)

- [x] [コーディング規約](https://github.com/PROJECT-PIPLUP/lounas/blob/develop/_docs/CODING.md)を確認しました。
- [x] [ディレクトリ構成](https://github.com/PROJECT-PIPLUP/lounas/blob/develop/_docs/DIRECTORY.md)を確認しました。
- [x] `npm run format`を実行しても`Error`は出ませんでした。
- [x] `npm run format`を実行しても`Warning`は最小限でした。
- [x] Google Chrome で表示を確認しました。
- [x] Firefox で表示を確認しました。
- [x] Google Chrome (iPhone 12 Pro) で表示を確認しました。
- [x] iPhone Safari で表示を確認しました。
- [x] [行動規範(Code of Conduct)](https://github.com/PROJECT-PIPLUP/lounas/blob/develop/_docs/CODE_OF_CONDUCT.md)に同意します。

## Remark

補足事項を記入してください。
