### PR TITLE
[GitHub] Remove Attribution from SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -32,10 +32,6 @@ To help maintain a secure environment, please adhere to the following best pract
 
 This security policy applies to the **lounas** project. Security issues outside the scope of this project or non-security-related issues will not be eligible for rewards.
 
-## Attribution
-
-This security policy is adapted from the [Open Source Security Standard](https://github.com/ossf/security-standard).
-
 ## Contact
 
 For security-related inquiries or to report a vulnerability, please contact **[@wiyco](https://github.com/wiyco)**.


### PR DESCRIPTION
# Features

Dev. 🐧

## What does this PR do?

- Remove Attribution from SECURITY.md.

## Before submitting

> **Warning**
>
> The following is allowed for review only. (No additions or modifications are permitted.)

- [x] I have read the [Contribution Guidelines](https://github.com/PROJECT-PIPLUP/lounas/blob/gh/.github/CONTRIBUTING.md).
- [x] I agree to the [Code of Conduct](https://github.com/PROJECT-PIPLUP/lounas/blob/gh/.github/CODE_OF_CONDUCT.md).

## Remark

Remark